### PR TITLE
Show display_name as final column (for LDAP integration users)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ To generate the report for a user, run the following command:
 
 ```
 $ sudo -u www-data ./occ usage-report:generate admin
-"admin","2017-09-18T09:00:01+00:00",5368709120,786432000,12,1,1,2
+"admin","2017-09-18T09:00:01+00:00",5368709120,786432000,12,1,1,2,"Nextcloud Admin"
 ```
 
 Leaving out the user argument will generate a report for all users on the system:
 
 ```
 $ sudo -u www-data ./occ usage-report:generate
-"admin","2017-09-18T09:00:01+00:00",5368709120,786432000,12,1,1,2
-"test1","2017-09-18T09:00:01+00:00",-2,954368,6,0,2,10
-"test2","2017-09-18T09:00:01+00:00",-2,164,4,0,0,0
-"test3","2017-09-18T09:00:01+00:00",-2,164,4,0,0,0
-"test5","2017-09-18T09:00:01+00:00",-2,164,4,0,0,0
+"admin","2017-09-18T09:00:01+00:00",5368709120,786432000,12,1,1,2,"Nextcloud Admin"
+"test1","2017-09-18T09:00:01+00:00",-2,954368,6,0,2,10,"Test User 1"
+"test2","2017-09-18T09:00:01+00:00",-2,164,4,0,0,0,"Second Test user"
+"test3","2017-09-18T09:00:01+00:00",-2,164,4,0,0,0,"Test User Three"
+"test5","2017-09-18T09:00:01+00:00",-2,164,4,0,0,0,"Fifth Tester"
 ```
 
 The CSV data is the following:
@@ -28,3 +28,5 @@ The CSV data is the following:
 * Number of shares created
 * Number of files created (new files only)
 * Number of files read (download/view)
+* User display name
+

--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -112,6 +112,7 @@ class Generate extends Command {
 			$data .= 'number of shares'. $separator;
 			$data .= 'number of uploads'. $separator;
 			$data .= 'number of downloads'. $separator;
+			$data .= 'display name'. $separator;
 			$output->writeln($data);
 		}
 

--- a/lib/Formatter.php
+++ b/lib/Formatter.php
@@ -46,7 +46,7 @@ trait Formatter {
 		$data .= $report['shares'] . $separator;
 		$data .= $report['uploads'] . $separator;
 		$data .= $report['downloads'] . $separator;
-	        $data .= $report['display_name'];
+	        $data .= '"' . $report['display_name'] . '"';
 	
 		$output->writeln($data);
 	}

--- a/lib/Formatter.php
+++ b/lib/Formatter.php
@@ -45,10 +45,9 @@ trait Formatter {
 		$data .= $report['files'] . $separator;
 		$data .= $report['shares'] . $separator;
 		$data .= $report['uploads'] . $separator;
-		$data .= $report['downloads'];
-		if (isset($report['display_name'])) {
-		  $data .= $separator . $report['display_name'];
-		}
+		$data .= $report['downloads'] . $separator;
+	        $data .= $report['display_name'];
+	
 		$output->writeln($data);
 	}
 

--- a/lib/Formatter.php
+++ b/lib/Formatter.php
@@ -46,6 +46,9 @@ trait Formatter {
 		$data .= $report['shares'] . $separator;
 		$data .= $report['uploads'] . $separator;
 		$data .= $report['downloads'];
+		if (isset($report['display_name'])) {
+		  $data .= $separator . $report['display_name'];
+		}
 		$output->writeln($data);
 	}
 

--- a/lib/Reports/AllUsers.php
+++ b/lib/Reports/AllUsers.php
@@ -80,6 +80,7 @@ class AllUsers {
 			'quota' => $this->config->getAppValue('files', 'default_quota', FileInfo::SPACE_UNKNOWN),
 			'shares' => 0,
 			'login' => 0,
+			'display_name' => '',
 		];
 
 		$progress = new ProgressBar($output);
@@ -87,6 +88,7 @@ class AllUsers {
 		$i = 0;
 		$this->userManager->callForAllUsers(function(IUser $user) use ($default, $progress, &$i) {
 			$this->reports[$user->getUID()] = $default;
+			$this->reports[$user->getUID()]['display_name'] = $user->getDisplayName();
 
 			$home = 'home::' . $user->getUID();
 			if (strlen($home) > 64) {

--- a/lib/Reports/SingleUser.php
+++ b/lib/Reports/SingleUser.php
@@ -211,9 +211,10 @@ class SingleUser {
 		$query = $this->queries['displayName'];
 		$query->setParameter('user', $userId);
 		$result = $query->execute();
-		$displayName = $result->fetchColumn();
+		$data = $result->fetchColumn();
 		$result->closeCursor();
-
+		$json = json_decode($data, TRUE);
+		$displayName = $json['displayname']['value'];
 		return (string) $displayName;
 	}
 
@@ -294,5 +295,13 @@ class SingleUser {
 			->where($query->expr()->eq('user_id', $query->createParameter('user')))
 			->groupBy('action');
 		$this->queries['countActions'] = $query;
+
+	        // Get User Display Name
+		$query = $this->connection->getQueryBuilder();
+		$query->select('data')
+			->from('accounts')
+		  ->where($query->expr()->eq('uid', $query->createParameter('user')));
+		$this->queries['displayName'] = $query;
+
 	}
 }

--- a/lib/Reports/SingleUser.php
+++ b/lib/Reports/SingleUser.php
@@ -66,6 +66,8 @@ class SingleUser {
 			$report['login'] = $this->getUserLastLogin($userId);
 		}
 		$report['shares'] = $this->getNumberOfSharesForUser($userId);
+		$report['display_name'] = $this->getUserDisplayName($userId);
+		
 
 		$this->printRecord($input, $output, $userId, $report);
 	}
@@ -201,6 +203,21 @@ class SingleUser {
 		return $numShares;
 	}
 
+	/**
+	 * @param string $userId
+	 * @return int
+	 */
+	protected function getUserDisplayName($userId) {
+		$query = $this->queries['displayName'];
+		$query->setParameter('user', $userId);
+		$result = $query->execute();
+		$displayName = $result->fetchColumn();
+		$result->closeCursor();
+
+		return (string) $displayName;
+	}
+
+	
 	/**
 	 * @param string $action
 	 * @return string


### PR DESCRIPTION
Currently the Nextcloud LDAP integration stores each user's user_id as a GUID.  This makes it incredibly difficult to use the output of the usage report - one has to visit the Admin->users screen and then manually search through for the GUID.  You can't hit Ctrl-F because the NC search that intercepts it does not see the GUIDs when you search for them.  You cannot sort the column, and it endlessly refreshses as you scroll down.  the only option is to scroll through manually for each GUID and cross compare which is incredibly time consuming.

This pull request adds a display_name field as the last column in the CSV, so that the report provides meaningful data which matches up to users.