### PR TITLE
increase thumbnail cutof size to 256

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -48,7 +48,7 @@ class Application extends App implements IBootstrap {
 		Util::connectHook('OC_Filesystem', 'read', $listener, 'fileRead');
 
 		$context->getServerContainer()->getEventDispatcher()->addListener(IPreview::EVENT, function (GenericEvent $event) use ($listener) {
-			if ($event->getArgument('width') > 64 || $event->getArgument('height') > 64) {
+			if ($event->getArgument('width') > 256 || $event->getArgument('height') > 256) {
 				$listener->fileRead();
 			}
 		});


### PR DESCRIPTION
grid view uses size 256 previews and we don't want those to count

Signed-off-by: Robin Appelman <robin@icewind.nl>