### PR TITLE
fix: check if array offset exists before accessing it

### DIFF
--- a/lib/Formatter.php
+++ b/lib/Formatter.php
@@ -37,13 +37,13 @@ trait Formatter {
 		$jsonArray = ['user_id' => $userId];
 		$data = '"'. $userId . '"'. $separator;
 		if ($input->getOption('display-name')) {
-			$jsonArray['display_name'] = $report['display_name'];
-			$data .= '"' . $report['display_name'] . '"' . $separator;
+			$jsonArray['display_name'] = $report['display_name'] ?? 'no display name found';
+			$data .= '"' . ($report['display_name'] ?? 'no display name found') . '"' . $separator;
 		}
 		$jsonArray['date'] = $this->timestamp;
 		$data .= '"'. $this->timestamp . '"'. $separator;
 		if ($input->getOption('last-login')) {
-			$report['login'] = date($input->getOption('date-format'), $report['login']);
+			$report['login'] = isset($report['login']) ? date($input->getOption('date-format'), $report['login']) : 'no last login found';
 			$jsonArray['login'] = $report['login'];
 			$data .= '"'. $report['login'] . '"'. $separator;
 		}


### PR DESCRIPTION
Found in a debug log:

```
{"reqId":"l1DCHRWoQVqlURBqNv0k","level":3,"time":"October 05, 2023 03:55:42","remoteAddr":"","user":"--","app":"PHP","method":"","url":"--","message":"Undefined array key \"login\" at /var/www/html/apps/user_usage_report/lib/Formatter.php#46","userAgent":"--","version":"27.0.2.2","data":{"app":"PHP"}}
{"reqId":"l1DCHRWoQVqlURBqNv0k","level":3,"time":"October 05, 2023 03:55:42","remoteAddr":"","user":"--","app":"PHP","method":"","url":"--","message":"Undefined array key \"display_name\" at /var/www/html/apps/user_usage_report/lib/Formatter.php#40","userAgent":"--","version":"27.0.2.2","data":{"app":"PHP"}}
{"reqId":"l1DCHRWoQVqlURBqNv0k","level":3,"time":"October 05, 2023 03:55:42","remoteAddr":"","user":"--","app":"PHP","method":"","url":"--","message":"Undefined array key \"display_name\" at /var/www/html/apps/user_usage_report/lib/Formatter.php#41","userAgent":"--","version":"27.0.2.2","data":{"app":"PHP"}}
```