### PR TITLE
[stable33] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-d4697182231bf364a34d8dd8b9e52a00 appstore-build-publish.yml
-5a7b85f72877c560683ba523ffad11cc block-unconventional-commits.yml
+fe1239ed98a163abbdea3e0490c85458 appstore-build-publish.yml
+19ab9c47c8d96de93f37fab242c398cc block-unconventional-commits.yml
 e6351c608939c31ae1e32923aa82aa10 dependabot-approve-merge.yml
 2581a67c5bcdcd570427e6d51db767d7 fixup.yml
-023b664746d1f2e09a9aaaac772ff7f5 lint-info-xml.yml
-870b483dbcbca59479211270d61546dd lint-php-cs.yml
-ee2b04d185b82fe7dd6fe6d83c6c7b45 lint-php.yml
-3c4a096b3b7dbaef0f8e5190ffe13518 pr-feedback.yml
-20b5d0d45766e3793f19c9c0c8d05140 psalm.yml
-3975dc58817119d596a8f6ed190352ce reuse.yml
+43fd0c5fb704cabc5f11cdfaf513236d lint-info-xml.yml
+4b40dd0073e16f74dd04e6d49dcc043d lint-php-cs.yml
+cfb31e47b6e9ab65e76c89b028754a4e lint-php.yml
+d1821b8a816578070ed8fd018f321f6d pr-feedback.yml
+6dc046dfbca5dc65d938265c518fcac4 psalm.yml
+2dbec18233063b42f4d8e03bbb43671c reuse.yml
 a3440826636c0fd7c2d20b1de50363da update-nextcloud-ocp-approve-merge.yml
-39db87018db395caf41007931817cdbd update-nextcloud-ocp.yml
+f5632e6d28c6afca9d4d46131fb48d57 update-nextcloud-ocp.yml

--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -35,7 +35,7 @@ jobs:
           echo "APP_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           path: ${{ env.APP_NAME }}
@@ -71,7 +71,7 @@ jobs:
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         # Skip if no package.json
         if: ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
           package-manager-cache: false
@@ -103,9 +103,11 @@ jobs:
 
       - name: Install composer dependencies
         if: steps.check_composer.outputs.files_exists == 'true'
-        run: |
-          cd ${{ env.APP_NAME }}
-          composer install --no-dev
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          composer-options: '--no-dev'
+          working-directory: ${{ env.APP_NAME }}
+          ignore-cache: 'yes'
 
       - name: Build ${{ env.APP_NAME }}
         # Skip if no package.json
@@ -157,7 +159,7 @@ jobs:
           unzip nextcloud.zip
 
       - name: Checkout server master fallback
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ steps.server-download.outcome != 'success' }}
         with:
           persist-credentials: false

--- a/.github/workflows/block-unconventional-commits.yml
+++ b/.github/workflows/block-unconventional-commits.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -24,7 +24,7 @@ jobs:
     name: info.xml lint
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -43,10 +43,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
+      - name: Remove nextcloud/ocp
         run: |
           composer remove nextcloud/ocp --dev --no-scripts
-          composer i
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Lint
         run: composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -25,7 +25,7 @@ jobs:
       php-max: ${{ steps.versions.outputs.php-max }}
     steps:
       - name: Checkout app
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -36,7 +36,7 @@ jobs:
           blocklist=$(curl https://raw.githubusercontent.com/nextcloud/.github/master/non-community-usernames.txt | paste -s -d, -)
           echo "blocklist=$blocklist" >> "$GITHUB_OUTPUT"
 
-      - uses: nextcloud/pr-feedback-action@f0cab224dea8e1f282f9451de322f323c78fc7a5 # main
+      - uses: nextcloud/pr-feedback-action@5227c55be184087d0aef6338bee210d8620b6297 # v1.0.1
         with:
           feedback-message: |
             Hello there,

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -24,7 +24,7 @@ jobs:
     name: static-psalm-analysis
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -47,12 +47,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
+      - name: Remove nextcloud/ocp
         run: |
           composer remove nextcloud/ocp --dev --no-scripts
-          composer i
 
-      - name: Install nextcloud/ocp
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+
+      - name: Install nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }}
         run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest-low
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - id: checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ matrix.branches }}
@@ -62,9 +62,9 @@ jobs:
           grep '/appinfo/info.xml' .github/CODEOWNERS | cut -f 2- -d ' ' | xargs | awk '{ print "codeowners="$0 }' >> $GITHUB_OUTPUT
         continue-on-error: true
 
-      - name: Composer install
+      - name: Install composer dependencies
         if: steps.checkout.outcome == 'success'
-        run: composer install
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Check composer bin for nextcloud/ocp exists
         id: check_composer_bin


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [appstore-build-publish.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/appstore-build-publish.yml)
- 🆙 Updated [block-unconventional-commits.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/block-unconventional-commits.yml)
- 🆙 Updated [lint-info-xml.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-info-xml.yml)
- 🆙 Updated [lint-php-cs.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php-cs.yml)
- 🆙 Updated [lint-php.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php.yml)
- 🆙 Updated [pr-feedback.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/pr-feedback.yml)
- 🆙 Updated [psalm.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/psalm.yml)
- 🆙 Updated [reuse.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/reuse.yml)
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)